### PR TITLE
keep top level msg as string instead of object

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,12 +116,8 @@ KafkaLogger.prototype.log = function(level, msg, meta, callback) {
         }
     }
     logMessage.level = level;
-    var jsonMsg = {}
-    jsonMsg.text = msg;
-    for (var property in meta) {
-        jsonMsg[property] = meta[property];
-    }
-    logMessage.msg = jsonMsg;
+    logMessage.msg = msg;
+    logMessage.fields = meta;
 
     if (!this.connected && Date.now() < this.initTime + 5000) {
         return this.initQueue.push([logMessage, callback]);


### PR DESCRIPTION
Currently msg is a string (with stringified json) and found out that it is better to keep it as string so no semantic change. Just need to add the meta object to logMessage.