### PR TITLE
Update nodesol write & xtend

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/uber/kafka-logger/issues"
   },
   "dependencies": {
-    "nodesol-write": "2.0.0",
+    "nodesol-write": "2.0.1",
     "winston-uber": "^1.0.0",
     "xtend": "~2.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "nodesol-write": "2.0.1",
     "winston-uber": "^1.0.0",
-    "xtend": "~2.1.1"
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "istanbul": "~0.1.46",


### PR DESCRIPTION
update nodesol-write to propagate nested node_module pruning of dev deps

xtend also updated to 4.0.0. xtend is currently used to shallow clone `var logMessage = extend(this.logTemplate);` and this behavior continues to work.