### PR TITLE
flushing the buffer when kafkaRestClient is connected

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ function KafkaLogger(options) {
                 self.logger.info('KafkaRestClient connected to kafka');
             }
             self.kafkaRestClientConnected = true;
+            self._flush();
         } else {
             if (self.logger) {
                 self.logger.warn('KafkaRestClient could not connect to kafka');


### PR DESCRIPTION
As usually kafka rest client will be slower than kafka leaf client for initialization.
Need to flush the queue after initialization.