### PR TITLE
upgrade node-kafka-rest-client to v1.1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,10 +102,20 @@ function KafkaLogger(options) {
     this.initTime = null;
     if (!this.kafkaRestClient) {
         if (this.proxyPort) {
-            this.kafkaRestClient = new KafkaRestClient({
+            var kafkaRestClientOptions = {
                 proxyHost: this.proxyHost,
                 proxyPort: this.proxyPort
-            });
+            };
+            if ('maxRetries' in options) {
+                kafkaRestClientOptions['maxRetries'] = options.maxRetries;
+            }
+            if ('blacklistMigrator' in options && 'blacklistMigratorUrl' in options) {
+                if (options.blacklistMigrator) {
+                    kafkaRestClientOptions['blacklistMigrator'] = options.blacklistMigrator;
+                    kafkaRestClientOptions['blacklistMigratorUrl'] = options.blacklistMigratorUrl;
+                }
+            }
+            this.kafkaRestClient = new KafkaRestClient(kafkaRestClientOptions);
             this.kafkaRestClient.connect(onKafkaRestClientConnect);
         }
     } else {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/uber/kafka-logger/issues"
   },
   "dependencies": {
-    "kafka-rest-client": "^1.0.0",
+    "kafka-rest-client": "^1.1.0",
     "nodesol-write": "2.0.1",
     "winston-uber": "^1.0.0",
     "xtend": "^4.0.0"

--- a/test/kafka.js
+++ b/test/kafka.js
@@ -69,7 +69,9 @@ test('KafkaLogger double writes to a real kafka server', function (assert) {
       leafHost: 'localhost',
       leafPort: server.port,
       proxyHost: 'localhost',
-      proxyPort: 4444
+      proxyPort: 4444,
+      blacklistMigrator: true,
+      blacklistMigratorUrl: 'localhost:2222'
   });
 
   logger.log('error', 'some message');


### PR DESCRIPTION
upgrade node-kafka-rest-client  version to enable retries and migrator blacklist.